### PR TITLE
Space/Tab indentations

### DIFF
--- a/Tabright.py
+++ b/Tabright.py
@@ -21,9 +21,9 @@ class TabrightEvent(sublime_plugin.EventListener):
 			window.focus_view(view)
 
 	def on_new(self,view):
-	    def callback(view=view):
+		def callback(view=view):
 			return self.move_tab(view)
-	    sublime.set_timeout(callback,1)
+		sublime.set_timeout(callback,1)
 
 	def on_activated(self,view):
 		if not view.settings().get("Tabright_processed"):


### PR DESCRIPTION
The below error occurred when loading this plugin in Sublime Text 3. Updated file to only include tab indentation. Appears to now be working with Sublime Text 3.

```
Tabright.sublime-package", line 25
    return self.move_tab(view)
                             ^
TabError: inconsistent use of tabs and spaces in indentation
```
